### PR TITLE
Make DEST default to target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,13 @@
-.PHONY: all install
+.PHONY: mvn-compile install
 
-all:
-	cd mod; mvn -nsu clean install
+all: mvn-compile install
 
-install: bin/modulec
+mvn-compile:
+	mvn -nsu clean install
 
-bin/modulec: src/main/java/modulec.java bin
+install: bin/modulec-shebang
+
+bin/modulec-shebang: src/main/java/modulec.java bin
 	printf "#!/home/hakon/share/jdk-11/bin/java --source 11\n\n" > $@
 	cat $< >> $@
 	chmod +x $@
-
-bin:
-	mkdir bin
-
-
-clean:
-	rm -rf bin

--- a/bin/modulec-shebang
+++ b/bin/modulec-shebang
@@ -1,3 +1,5 @@
+#!/home/hakon/share/jdk-11/bin/java --source 11
+
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ModuleTree;

--- a/bin/modulec-wrapper.sh
+++ b/bin/modulec-wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if ! type readlink &> /dev/null
+then
+    echo "Missing dependency: readlink"
+    exit 1
+elif ! type java &> /dev/null
+then
+    echo "Missing dependency: java"
+fi
+
+# To launch the Java JVM with the modulec main class, we need to locate it.
+# We'll assume modulec.class is in ../target/classes relative to the directory
+# this file is in, so the task is reduced to finding what directory we're in.
+#
+# 'readlink -m "$0/.."' has been verified to work for these cases:
+# 1. PWD is somewhere else, and a relative path is used to refer to this file.
+# 2. PWD is somewhere else, and a symlink contains the relative path to this
+# file.
+# 3. PWD is somewhere else and PATH contains this directory.
+#
+# Therefore, the class path must be set to...
+class_path=$(readlink -m "$0/.."/../target/classes)
+
+if ! test -r "$class_path"/modulec.class
+then
+    echo "error: modulec file does not exist: $class_path/modulec.class"
+    exit 1
+fi
+
+exec java -cp "$class_path" modulec "$@"

--- a/src/test/java/BasicTest.java
+++ b/src/test/java/BasicTest.java
@@ -1,6 +1,7 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -12,14 +13,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BasicTest {
     private final Path basicPath = Path.of("src/test/resources/basic");
+    private final Path targetPath = basicPath.resolve("target");
     private final modulec modulec = new modulec(FileSystems.getDefault());
+
+    @BeforeEach
+    void setUp() throws IOException {
+        if (Files.exists(targetPath)) {
+            deleteRecursively(targetPath.toFile());
+        }
+    }
 
     @Test
     void verifyBasicCompile() throws IOException  {
         int exitCode = modulec.noExitMain(
-                "-f", basicPath.resolve("target").toString() + '/',
                 "-v", "1.0.0",
-                "-d", basicPath.resolve("target/classes").toString(),
+                "-d", basicPath.resolve("target").toString(),
                 basicPath.resolve("src").toString());
         assertEquals(0, exitCode);
         assertTrue(Files.exists(basicPath.resolve("target/no.ion.tst-1.0.0.jar")));
@@ -27,5 +35,18 @@ class BasicTest {
         assertTrue(Files.exists(basicPath.resolve("target/classes/no/ion/tst1/Exported.class")));
         assertFalse(Files.exists(basicPath.resolve("target/classes/.src")));
         assertFalse(Files.exists(basicPath.resolve("target/classes/.classes")));
+    }
+
+    private void deleteRecursively(File existingFile) {
+        if (!Files.isSymbolicLink(existingFile.toPath())) {
+            File[] directoryFiles = existingFile.listFiles();
+            if (directoryFiles != null) {
+                for (File directoryFile : directoryFiles) {
+                    deleteRecursively(directoryFile);
+                }
+            }
+        }
+
+        existingFile.delete();
     }
 }


### PR DESCRIPTION
Also adds various other improvements:
 - Adds a bin/modulec-wrapper.sh that invokes (readlink and) java to execute
   modulec, shown to be on par with javac+jar.
 - Adds bin/modulec-shebang.
 - Users can add a symlink modulec in PATH to either of above.
   modulec-wrapper.sh must not be moved, and the maven project should be built.
 - Make DEST a directory modulec has discretion to use for whatever purpose it
   sees fit:  embeds a classes directory for .class files, keeps symlinks used
   during build, and will by default output JAR file there.  Together with
   target being the default DEST, this simplifies output options.