### PR TITLE
Supply .java files to javac

### DIFF
--- a/bin/modulec-shebang
+++ b/bin/modulec-shebang
@@ -9,26 +9,37 @@ import com.sun.source.tree.ModuleTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.JavacTask;
 
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticListener;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleDescriptor;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
@@ -147,18 +158,18 @@ public class ModuleCompiler {
         try {
             options.validate();
 
-            String moduleName = getModuleName(options.sourceDirectory.resolve("module-info.java"));
             var classesPath = options.outputDirectory.resolve("classes");
 
-            SuccessResult result = runJavaCompiler(options, moduleName, classesPath);
+            SuccessResult result = runJavaCompiler(options, classesPath);
 
+            String moduleName = getModuleName(options.sourceDirectory.resolve("module-info.java"));
             return runJarTool(options, moduleName, classesPath, result);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    String getModuleName(Path moduleInfoPath) throws IOException {
+    protected String getModuleName(Path moduleInfoPath) throws IOException {
         List<String> moduleNames = new ArrayList<>();
 
         try(StandardJavaFileManager fileManager = javaCompiler.getStandardFileManager(null, null, null)) {
@@ -193,43 +204,111 @@ public class ModuleCompiler {
         }
     }
 
-    private SuccessResult runJavaCompiler(Options options, String moduleName, Path classesPath) throws IOException {
-        var javacDestPath = options.outputDirectory.resolve("javac-classes");
-        var moduleSourcePath = options.outputDirectory.resolve("javac-src");
-
-        Files.createDirectories(classesPath);
-        ensureSymlinkTo(options, javacDestPath.resolve(moduleName), "../classes");
-        ensureSymlinkTo(options, moduleSourcePath.resolve(moduleName), options.sourceDirectory.toAbsolutePath().toString());
-
-        var javacArgs = new ArrayList<String>();
+    private SuccessResult runJavaCompiler(Options options, Path classesPath) throws IOException {
+        var javacOptions = new ArrayList<String>();
         if (options.path != null) {
-            javacArgs.add("-p");
-            javacArgs.add(options.path);
+            javacOptions.add("-p");
+            javacOptions.add(options.path);
         }
-        javacArgs.add("--module-source-path");
-        javacArgs.add(moduleSourcePath.toString());
-        javacArgs.add("-m");
-        javacArgs.add(moduleName);
         if (options.version != null) {
-            javacArgs.add("--module-version");
-            javacArgs.add(options.version.toString());
+            javacOptions.add("--module-version");
+            javacOptions.add(options.version.toString());
         }
-        javacArgs.add("-d");
-        javacArgs.add(javacDestPath.toString());
-        javacArgs.addAll(options.javacArgs);
+
+        javacOptions.add("-d");
+        javacOptions.add(classesPath.toString());
+        javacOptions.addAll(options.javacArgs);
+
+        List<Path> javacSourceFiles = new ArrayList<>();
+        Deque<Path> directoryQueue = new ArrayDeque<>();
+        directoryQueue.add(options.sourceDirectory);
+        while (!directoryQueue.isEmpty()) {
+            Path directory = directoryQueue.removeFirst();
+            try (DirectoryStream<Path> dentryPathStream = Files.newDirectoryStream(directory)) {
+                for (Path path : dentryPathStream) {
+                    if (Files.isDirectory(path)) {
+                        directoryQueue.addLast(path);
+                    } else if (path.getFileName().toString().endsWith(".java")) {
+                        javacSourceFiles.add(path);
+                    }
+                }
+            }
+        }
 
         if (options.dryRun) {
-            return new SuccessResult("javac " + String.join(" ", javacArgs) + "\n");
+            String command = "javac " + Stream
+                    .concat(javacOptions.stream(), javacSourceFiles.stream().map(Path::toString))
+                    .collect(Collectors.joining(" "));
+            return new SuccessResult(command + "\n");
         }
 
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
-        int code = javaCompiler.run(inputStream, outputStream, outputStream, javacArgs.toArray(String[]::new));
+        return compile(javacOptions, javacSourceFiles);
+    }
 
-        if (code == 0) {
-            return new SuccessResult(outputStream.toString());
+    protected SuccessResult compile(List<String> javacOptions, List<Path> javacSourceFiles) throws ModuleCompilerException {
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = new ArrayList<>();
+        var listener = new DiagnosticListener<JavaFileObject>() {
+            @Override
+            public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+                diagnostics.add(diagnostic);
+            }
+        };
+
+        StandardJavaFileManager standardFileManager = javaCompiler.getStandardFileManager(null, null, null);
+        Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromPaths(javacSourceFiles);
+
+        var fileManager = new ForwardingJavaFileManager<>(standardFileManager) {
+            @Override
+            public JavaFileObject getJavaFileForOutput(Location location, String className, JavaFileObject.Kind kind, FileObject sibling)
+                    throws IOException {
+                // sibling.getName(): src/module-info.java
+                // className: module-info
+                return super.getJavaFileForOutput(location, className, kind, sibling);
+            }
+        };
+
+        var writer = new StringWriter();
+        JavaCompiler.CompilationTask task = javaCompiler.getTask(writer, fileManager, listener, javacOptions, null, compilationUnits);
+
+        boolean success = task.call();
+
+        // It appears that if there is an error, no warnings are shown. Not sure about NOTE, MANDATORY_WARNING, and OTHER.
+        var message = new StringBuilder();
+
+        String writtenString = writer.toString();
+        if (!writtenString.isEmpty()) {
+            message.append(writtenString);
+        }
+
+        int errorCount = 0;
+        int warningCount = 0;
+        for (var diagnostic : diagnostics) {
+            switch (diagnostic.getKind()) {
+                case ERROR:
+                    ++errorCount;
+                    break;
+                case WARNING:
+                case MANDATORY_WARNING:
+                    ++warningCount;
+                    break;
+                default:
+                    // nothing
+            }
+
+            message.append(diagnostic.toString()).append('\n');
+        }
+
+        if (errorCount > 0) {
+            message.append(errorCount).append(" error").append(errorCount == 1 ? '\n' : "s\n");
+        }
+        if (warningCount > 0) {
+            message.append(warningCount).append(" warning").append(warningCount == 1 ? '\n' : "s\n");
+        }
+
+        if (success) {
+            return new SuccessResult(message.toString());
         } else {
-            throw new ModuleCompilerException(outputStream.toString());
+            throw new ModuleCompilerException(message.toString());
         }
     }
 

--- a/src/main/java/no/ion/modulec/ModuleCompiler.java
+++ b/src/main/java/no/ion/modulec/ModuleCompiler.java
@@ -7,26 +7,37 @@ import com.sun.source.tree.ModuleTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.JavacTask;
 
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticListener;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleDescriptor;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
@@ -145,18 +156,18 @@ public class ModuleCompiler {
         try {
             options.validate();
 
-            String moduleName = getModuleName(options.sourceDirectory.resolve("module-info.java"));
             var classesPath = options.outputDirectory.resolve("classes");
 
-            SuccessResult result = runJavaCompiler(options, moduleName, classesPath);
+            SuccessResult result = runJavaCompiler(options, classesPath);
 
+            String moduleName = getModuleName(options.sourceDirectory.resolve("module-info.java"));
             return runJarTool(options, moduleName, classesPath, result);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    String getModuleName(Path moduleInfoPath) throws IOException {
+    protected String getModuleName(Path moduleInfoPath) throws IOException {
         List<String> moduleNames = new ArrayList<>();
 
         try(StandardJavaFileManager fileManager = javaCompiler.getStandardFileManager(null, null, null)) {
@@ -191,43 +202,110 @@ public class ModuleCompiler {
         }
     }
 
-    private SuccessResult runJavaCompiler(Options options, String moduleName, Path classesPath) throws IOException {
-        var javacDestPath = options.outputDirectory.resolve("javac-classes");
-        var moduleSourcePath = options.outputDirectory.resolve("javac-src");
-
-        Files.createDirectories(classesPath);
-        ensureSymlinkTo(options, javacDestPath.resolve(moduleName), "../classes");
-        ensureSymlinkTo(options, moduleSourcePath.resolve(moduleName), options.sourceDirectory.toAbsolutePath().toString());
-
-        var javacArgs = new ArrayList<String>();
+    private SuccessResult runJavaCompiler(Options options, Path classesPath) throws IOException {
+        var javacOptions = new ArrayList<String>();
         if (options.path != null) {
-            javacArgs.add("-p");
-            javacArgs.add(options.path);
+            javacOptions.add("-p");
+            javacOptions.add(options.path);
         }
-        javacArgs.add("--module-source-path");
-        javacArgs.add(moduleSourcePath.toString());
-        javacArgs.add("-m");
-        javacArgs.add(moduleName);
         if (options.version != null) {
-            javacArgs.add("--module-version");
-            javacArgs.add(options.version.toString());
+            javacOptions.add("--module-version");
+            javacOptions.add(options.version.toString());
         }
-        javacArgs.add("-d");
-        javacArgs.add(javacDestPath.toString());
-        javacArgs.addAll(options.javacArgs);
+
+        javacOptions.add("-d");
+        javacOptions.add(classesPath.toString());
+        javacOptions.addAll(options.javacArgs);
+
+        List<Path> javacSourceFiles = new ArrayList<>();
+        Deque<Path> directoryQueue = new ArrayDeque<>();
+        directoryQueue.add(options.sourceDirectory);
+        while (!directoryQueue.isEmpty()) {
+            Path directory = directoryQueue.removeFirst();
+            try (DirectoryStream<Path> dentryPathStream = Files.newDirectoryStream(directory)) {
+                for (Path path : dentryPathStream) {
+                    if (Files.isDirectory(path)) {
+                        directoryQueue.addLast(path);
+                    } else if (path.getFileName().toString().endsWith(".java")) {
+                        javacSourceFiles.add(path);
+                    }
+                }
+            }
+        }
 
         if (options.dryRun) {
-            return new SuccessResult("javac " + String.join(" ", javacArgs) + "\n");
+            String command = "javac " + Stream
+                    .concat(javacOptions.stream(), javacSourceFiles.stream().map(Path::toString))
+                    .collect(Collectors.joining(" "));
+            return new SuccessResult(command + "\n");
         }
 
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
-        int code = javaCompiler.run(inputStream, outputStream, outputStream, javacArgs.toArray(String[]::new));
+        return compile(javacOptions, javacSourceFiles);
+    }
 
-        if (code == 0) {
-            return new SuccessResult(outputStream.toString());
+    protected SuccessResult compile(List<String> javacOptions, List<Path> javacSourceFiles) throws ModuleCompilerException {
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = new ArrayList<>();
+        var listener = new DiagnosticListener<JavaFileObject>() {
+            @Override
+            public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+                diagnostics.add(diagnostic);
+            }
+        };
+
+        StandardJavaFileManager standardFileManager = javaCompiler.getStandardFileManager(null, null, null);
+        Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromPaths(javacSourceFiles);
+
+        var fileManager = new ForwardingJavaFileManager<>(standardFileManager) {
+            @Override
+            public JavaFileObject getJavaFileForOutput(Location location, String className, JavaFileObject.Kind kind, FileObject sibling)
+                    throws IOException {
+                // sibling.getName(): src/module-info.java
+                // className: module-info
+                return super.getJavaFileForOutput(location, className, kind, sibling);
+            }
+        };
+
+        var writer = new StringWriter();
+        JavaCompiler.CompilationTask task = javaCompiler.getTask(writer, fileManager, listener, javacOptions, null, compilationUnits);
+
+        boolean success = task.call();
+
+        var message = new StringBuilder();
+
+        String writtenString = writer.toString();
+        if (!writtenString.isEmpty()) {
+            message.append(writtenString);
+        }
+
+        int errorCount = 0;
+        int warningCount = 0;
+        for (var diagnostic : diagnostics) {
+            switch (diagnostic.getKind()) {
+                case ERROR:
+                    ++errorCount;
+                    break;
+                case WARNING:
+                case MANDATORY_WARNING:
+                    ++warningCount;
+                    break;
+                default:
+                    // nothing?
+            }
+
+            message.append(diagnostic.toString()).append('\n');
+        }
+
+        if (errorCount > 0) {
+            message.append(errorCount).append(" error").append(errorCount == 1 ? '\n' : "s\n");
+        }
+        if (warningCount > 0) {
+            message.append(warningCount).append(" warning").append(warningCount == 1 ? '\n' : "s\n");
+        }
+
+        if (success) {
+            return new SuccessResult(message.toString());
         } else {
-            throw new ModuleCompilerException(outputStream.toString());
+            throw new ModuleCompilerException(message.toString());
         }
     }
 

--- a/src/test/java/no/ion/modulec/BadModuleInfoTest.java
+++ b/src/test/java/no/ion/modulec/BadModuleInfoTest.java
@@ -1,0 +1,39 @@
+package no.ion.modulec;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class BadModuleInfoTest {
+    @Test
+    void verifyModuleCompilerDiagnostics() {
+        var  compiler = ModuleCompiler.create();
+
+        Path root = Path.of("src/test/resources/bad-module-info");
+
+        var options = new ModuleCompiler.Options()
+                .setSourceDirectory(root.resolve("src"))
+                .setOutputDirectory(root.resolve("target"));
+
+        try {
+            compiler.make(options);
+            fail();
+        } catch (ModuleCompiler.ModuleCompilerException e) {
+            assertEquals("src/test/resources/bad-module-info/src/module-info.java:2: error: package is empty or does not exist: a.b\n" +
+                         "    exports a.b;\n" +
+                         "             ^\n" +
+                         "src/test/resources/bad-module-info/src/module-info.java:3: error: package is empty or does not exist: c.d\n" +
+                         "    exports c.d;\n" +
+                         "             ^\n" +
+                         "src/test/resources/bad-module-info/src/module-info.java:1: warning: [module] module name component tst1 should avoid terminal digits\n" +
+                         "module no.ion.tst1 {\n" +
+                         "             ^\n" +
+                         "2 errors\n" +
+                         "1 warning\n",
+                         e.getMessage());
+        }
+    }
+}

--- a/src/test/java/no/ion/modulec/BasicTest.java
+++ b/src/test/java/no/ion/modulec/BasicTest.java
@@ -30,13 +30,6 @@ class BasicTest {
             basicPath.resolve("src").toString()
     };
 
-    @BeforeEach @AfterEach
-    void setUp() {
-        if (Files.exists(targetPath)) {
-            deleteRecursively(targetPath.toFile());
-        }
-    }
-
     @Test
     void verifyCommandLineArgumentParsing() {
         assertInvalidOptions("error: no source directory");
@@ -78,6 +71,10 @@ class BasicTest {
 
     @Test
     void verifyNoExitMain() {
+        if (Files.exists(targetPath)) {
+            deleteRecursively(targetPath.toFile());
+        }
+
         verifyBasicIsBuilt(() -> {
             ModuleCompiler.SuccessResult result = ModuleCompiler.mainApi(argsForBasic);
             Optional<String> diagnostics = result.diagnostics();
@@ -87,6 +84,10 @@ class BasicTest {
 
     @Test
     void verifyMake() {
+        if (Files.exists(targetPath)) {
+            deleteRecursively(targetPath.toFile());
+        }
+
         var options = new ModuleCompiler.Options()
                 .setOutputDirectory(basicPath.resolve("target"))
                 .setVersion(ModuleDescriptor.Version.parse("1.2.3"))
@@ -111,10 +112,6 @@ class BasicTest {
         assertDirectory("target/classes");
         assertRegularFile("target/classes/module-info.class");
         assertRegularFile("target/classes/no/ion/tst1/Exported.class");
-        assertDirectory("target/javac-classes");
-        assertSymlink("target/javac-classes/no.ion.tst");
-        assertDirectory("target/javac-src");
-        assertSymlink("target/javac-src/no.ion.tst");
         assertRegularFile("target/no.ion.tst-1.2.3.jar");
     }
 
@@ -128,10 +125,6 @@ class BasicTest {
 
     private void assertRegularFile(String pathRelativeBasic) {
         assertTrue(Files.isRegularFile(basicPath.resolve(pathRelativeBasic)));
-    }
-
-    private void assertSymlink(String pathRelativeBasic) {
-        assertTrue(Files.isSymbolicLink(basicPath.resolve(pathRelativeBasic)));
     }
 
     private void deleteRecursively(File existingFile) {

--- a/src/test/resources/bad-module-info/src/module-info.java
+++ b/src/test/resources/bad-module-info/src/module-info.java
@@ -1,0 +1,4 @@
+module no.ion.tst1 {
+    exports a.b;
+    exports c.d;
+}


### PR DESCRIPTION
Supplies the *.java files to javac instead of using --module-source-path and
--module:
 - Allows controlling the module-info.java supplied to compilation.
 - Allows control when writing class files (not exploited yet).
 - Avoids having to create directory/symlink structure, which may conflict with
   user's expectations or other tools.
 - Removes the need to know the module name before compilation (not exploited
   yet).

Adds a test that verifies the diagnostics have not changed.

modulec.sh has not been updated (tbd).